### PR TITLE
ckanext-digitizationknowledge-44 Button missing a text alternative

### DIFF
--- a/ckanext/digitizationknowledge/templates/user/snippets/user_search.html
+++ b/ckanext/digitizationknowledge/templates/user/snippets/user_search.html
@@ -1,0 +1,15 @@
+<section class="module module-narrow module-shallow simple-input">
+    <h2 class="module-heading">{{ _('Users') }}</h2>
+    <form class="module-content field-bordered" action="{% url_for 'user.index' %}" method="get" id="user-search-form">
+        <div class="field">
+            <label for="field-user-search">{{ _('Search Users') }}</label>
+            <input id="field-user-search" value="{{ q }}" class="field form-control" name="q" placeholder="{{ _('Search') }}" />
+            <button class="btn-search" type="submit" aria-label="{{ _('Search Users') }}">
+                <i class="fa fa-search" aria-hidden="true"></i>
+            </button>
+        </div>
+    </form>
+    <ul class="nav nav-simple">
+        <li class="nav-item">{{ h.nav_link(_('All Users'), named_route='user.index') }}</li>
+    </ul>
+</section>


### PR DESCRIPTION
Addresses #44

This PR adds a text alternative (alt attribute) to the button that was missing it.

Note: This change needs to be merged and deployed to production before it can be properly tested with ADA SiteImprove.
Will test after merge.