### PR TITLE
Replace datastore-based choices with hardcoded values in schema YAML …

### DIFF
--- a/ckanext/digitizationknowledge/schemas/book.yaml
+++ b/ckanext/digitizationknowledge/schemas/book.yaml
@@ -121,12 +121,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -165,12 +171,10 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: book_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: book
+    label: Book
 
 - field_name: tag_string
   label: Tags
@@ -194,76 +198,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 

--- a/ckanext/digitizationknowledge/schemas/digital-document.yaml
+++ b/ckanext/digitizationknowledge/schemas/digital-document.yaml
@@ -89,12 +89,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -155,12 +161,22 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digital_document_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: protocol
+    label: Protocol
+  - value: guide
+    label: Guide
+  - value: presentation slides
+    label: Presentation Slides
+  - value: handbook
+    label: Handbook
+  - value: guidelines
+    label: Guidelines
+  - value: reference
+    label: Reference
+  - value: overview
+    label: Overview
 
 - field_name: tag_string
   label: Tags
@@ -184,76 +200,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 

--- a/ckanext/digitizationknowledge/schemas/event.yaml
+++ b/ckanext/digitizationknowledge/schemas/event.yaml
@@ -31,12 +31,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: owner_org
   label: Organization
@@ -57,12 +63,12 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: event_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: workshop
+    label: Workshop
+  - value: conference
+    label: Conference
 
 - field_name: tag_string
   label: Tags
@@ -86,76 +92,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 
@@ -196,12 +268,18 @@ resource_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free

--- a/ckanext/digitizationknowledge/schemas/learning-resource.yaml
+++ b/ckanext/digitizationknowledge/schemas/learning-resource.yaml
@@ -78,23 +78,27 @@ dataset_fields:
   label: Interactivity Type
   display_property: schema:interactivityType
   preset: select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: learning_resource_interactivity_type
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: syncronous
+    label: Syncronous
+  - value: asyncronous
+    label: Asyncronous
+  - value: mixed syncronous-asyncronous
+    label: Mixed Syncronous-Asyncronous
 
 - field_name: repeat_frequency
   label: Repeat Frequency
   display_property: schema:repeatFrequency
   preset: select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: learning_resource_repeat_frequency
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: on demand
+    label: On Demand
+  - value: self-paced
+    label: Self-paced
+  - value: scheduled
+    label: Scheduled
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -124,12 +128,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: copyright_holder
   label: Copyright Holder
@@ -165,12 +175,14 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: learning_resource_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: course
+    label: Course
+  - value: training
+    label: Training
+  - value: certification
+    label: Certification
 
 - field_name: tag_string
   label: Tags
@@ -194,76 +206,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 
 resource_fields:

--- a/ckanext/digitizationknowledge/schemas/scholarly-article.yaml
+++ b/ckanext/digitizationknowledge/schemas/scholarly-article.yaml
@@ -113,12 +113,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -153,12 +159,14 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: scholarly_article_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: preprint
+    label: Pre print
+  - value: journal article
+    label: Journal Article
+  - value: technical report
+    label: Technical Report
 
 - field_name: tag_string
   label: Tags
@@ -182,76 +190,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 

--- a/ckanext/digitizationknowledge/schemas/software-application.yaml
+++ b/ckanext/digitizationknowledge/schemas/software-application.yaml
@@ -72,12 +72,20 @@ dataset_fields:
   label: Operating System
   preset: multiple_select
   display_property: schema:operatingSystem
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: operating_system
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: linux
+    label: Linux
+  - value: windows
+    label: Windows
+  - value: macos
+    label: MacOS
+  - value: platform independent
+    label: Platform Independent
+  - value: ios
+    label: iOS
+  - value: android
+    label: Android
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -107,12 +115,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: copyright_holder
   label: Copyright Holder
@@ -149,12 +163,22 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: software_application_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: web application
+    label: Web Application
+  - value: desktop application
+    label: Desktop Application
+  - value: mobile application
+    label: Mobile Application
+  - value: api
+    label: API
+  - value: software package
+    label: Software Package
+  - value: web services
+    label: Web Services
+  - value: software suite
+    label: Software Suite
 
 - field_name: tag_string
   label: Tags
@@ -178,76 +202,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 
 resource_fields:

--- a/ckanext/digitizationknowledge/schemas/software-source-code.yaml
+++ b/ckanext/digitizationknowledge/schemas/software-source-code.yaml
@@ -72,23 +72,47 @@ dataset_fields:
   label: Operating System
   preset: multiple_select
   display_property: schema:operatingSystem
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: operating_system
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: linux
+    label: Linux
+  - value: windows
+    label: Windows
+  - value: macos
+    label: MacOS
+  - value: platform independent
+    label: Platform Independent
+  - value: ios
+    label: iOS
+  - value: android
+    label: Android
 
 - field_name: programming_language
   label: Programming Language
   preset: select
   display_property: schema:programmingLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: programming_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: python
+    label: Python
+  - value: r
+    label: R
+  - value: php
+    label: PHP
+  - value: javascript
+    label: JavaScript
+  - value: c
+    label: C
+  - value: perl
+    label: Perl
+  - value: c++
+    label: C++
+  - value: go
+    label: Go
+  - value: rust
+    label: Rust
+  - value: shell
+    label: Shell
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -149,12 +173,22 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: software_source_code_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: application source code
+    label: Application Source Code
+  - value: web application
+    label: Web Application
+  - value: desktop application
+    label: Desktop Application
+  - value: mobile application
+    label: Mobile Application
+  - value: web services
+    label: Web Services
+  - value: software package
+    label: Software Package
+  - value: command-line application
+    label: Command-Line Application
 
 - field_name: tag_string
   label: Tags
@@ -178,76 +212,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 
 resource_fields:

--- a/ckanext/digitizationknowledge/schemas/video-object.yaml
+++ b/ckanext/digitizationknowledge/schemas/video-object.yaml
@@ -99,12 +99,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -165,12 +171,18 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: video_object_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: video
+    label: Video
+  - value: workshop video
+    label: Workshop Video
+  - value: conference video
+    label: Conference Video
+  - value: learning-resource video
+    label: Learning-Resource Video
+  - value: webinar
+    label: Webinar
 
 - field_name: tag_string
   label: Tags
@@ -194,76 +206,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 

--- a/ckanext/digitizationknowledge/schemas/web-content.yaml
+++ b/ckanext/digitizationknowledge/schemas/web-content.yaml
@@ -78,12 +78,18 @@ dataset_fields:
   label: Language
   preset: multiple_select
   display_property: schema:inLanguage
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: in_language
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: eng
+    label: English
+  - value: spa
+    label: Spanish
+  - value: fra
+    label: French
+  - value: por
+    label: Portuguese
+  - value: deu
+    label: German
 
 - field_name: is_accessible_for_free
   label: Accessible for Free
@@ -144,12 +150,28 @@ dataset_fields:
   label: Category
   preset: select
   display_property: schema:category
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: web_content_category
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: protocol
+    label: Protocol
+  - value: guide
+    label: Guide
+  - value: resource hub
+    label: Resource Hub
+  - value: standard
+    label: Standard
+  - value: discussion forum
+    label: Discussion Forum
+  - value: listserv
+    label: Listserv
+  - value: handbook
+    label: Handbook
+  - value: guidelines
+    label: Guidelines
+  - value: reference
+    label: Reference
+  - value: overview
+    label: Overview
 
 - field_name: tag_string
   label: Tags
@@ -173,76 +195,142 @@ dataset_fields:
   label: Digitization Academy Courses
   preset: multiple_select
   display_property: dk:digitization_academy_course
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: digitization_academy_course
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: Introduction to Biodiversity Specimen Digitization
+    label: Introduction to Biodiversity Specimen Digitization
+  - value: Digital Imaging for Biodiversity Collections
+    label: Digital Imaging for Biodiversity Collections
+  - value: Public Participation in Digitization of Biodiversity Collections
+    label: Public Participation in Digitization of Biodiversity Collections
 
 - field_name: task_clusters
   label: Task Clusters
   help_text:
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task_clusters
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: pre-digitization curation
+    label: Pre-Digitization Curation
+  - value: digital data capture
+    label: Digital Data Capture
+  - value: georeferencing
+    label: Georeferencing
+  - value: project design and management
+    label: Project Design and Management
+  - value: general
+    label: General
+  - value: digital imaging
+    label: Digital Imaging
+  - value: mobilization and sharing
+    label: Mobilization and Sharing
 
 - field_name: task
   label: Task
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: task
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: whole-drawer imaging
+    label: Whole-Drawer Imaging
+  - value: label imaging
+    label: Label Imaging
+  - value: label transcription
+    label: Label Transcription
+  - value: quality control
+    label: Quality Control
+  - value: specimen imaging
+    label: Specimen Imaging
+  - value: image processing
+    label: Image Processing
+  - value: image capture
+    label: Image Capture
+  - value: transcription
+    label: Transcription
 
 - field_name: preparations
   label: Specimen Preparations
   preset: multiple_select
   display_property: dwc:preparations
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: preparations
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: herbarium sheets
+    label: Herbarium Sheets
+  - value: pinned dried insects
+    label: Pinned Dried Insects
+  - value: microscope slides
+    label: Microscope Slides
+  - value: flat sheets and packets
+    label: Flat Sheets and Packets
+  - value: pinned things in trays and drawers
+    label: Pinned Things in Trays and Drawers
+  - value: things in spirits in jars
+    label: Things in Spirits in Jars
+  - value: three-dimensional objects in trays and boxes
+    label: Three-Dimensional Objects in Trays and Boxes
+  - value: general
+    label: General
 
 - field_name: audience
   label: Audience
   preset: multiple_select
   display_property: schema:audience
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: audience
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: general
+    label: General
+  - value: collections professionals
+    label: Collections Professionals
+  - value: educators
+    label: Educators
+  - value: researchers
+    label: Researchers
+  - value: participatory science practitioners
+    label: Participatory Science Practitioners
+  - value: participatory science coordinators
+    label: Participatory Science Coordinators
 
 - field_name: discipline
   label: Discipline
   preset: multiple_select
   display_property: ltc:discipline
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: discipline
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: botany
+    label: Botany
+  - value: entomology
+    label: Entomology
+  - value: paleontology
+    label: Paleontology
+  - value: ornithology
+    label: Ornithology
+  - value: ichthyology
+    label: Ichthyology
+  - value: general
+    label: General
+  - value: zoology - arthropods
+    label: Zoology - Arthropods
+  - value: anthropology
+    label: Anthropology
+  - value: cultural heritage
+    label: Cultural Heritage
+  - value: geology
+    label: Geology
+  - value: mammalogy
+    label: Mammalogy
+  - value: zoology
+    label: Zoology
+  - value: ecology
+    label: Ecology
 
 - field_name: equipment
   label: Equipment
   preset: multiple_select
-  choices_helper: scheming_datastore_choices
   sorted_choices: true
-  datastore_choices_resource: equipment
-  datastore_choices_columns:
-    value: value
-    label: label
+  choices:
+  - value: 2d imaging
+    label: 2D Imaging
+  - value: 3d modeling
+    label: 3D modeling
 
 resource_fields:
 


### PR DESCRIPTION
This brings back setting values for standardized fields by modifying json files. This removes the short term need for the ckan data table views as these will be set to private in the meantime and in so it helps with all issues related to does data tables views. This pull request also partially addresses #43.