### PR TITLE
Update DOI display snippets to use `doi.html` template instead of `link.html` and add new `doi.html` template for enhanced DOI rendering

### DIFF
--- a/ckanext/digitizationknowledge/schemas/book.yaml
+++ b/ckanext/digitizationknowledge/schemas/book.yaml
@@ -33,7 +33,7 @@ dataset_fields:
   label: DOI
   form_placeholder: e.g., https://doi.org/10.3897/zookeys.209.3135
   display_property: dc:identifier:doi
-  display_snippet: link.html
+  display_snippet: doi.html
 
 - field_name: isbn
   label: ISBN
@@ -344,7 +344,7 @@ resource_fields:
 - field_name: doi
   label: DOI
   display_property: dc:identifier:doi
-  display_snippet: link.html
+  display_snippet: doi.html
 
 - field_name: isbn
   label: ISBN

--- a/ckanext/digitizationknowledge/schemas/scholarly-article.yaml
+++ b/ckanext/digitizationknowledge/schemas/scholarly-article.yaml
@@ -32,7 +32,7 @@ dataset_fields:
   label: DOI
   form_placeholder: e.g., https://doi.org/10.3897/zookeys.209.3135
   display_property: dc:identifier:doi
-  display_snippet: link.html
+  display_snippet: doi.html
 
 - field_name: author
   label: First Author
@@ -338,7 +338,7 @@ resource_fields:
   label: DOI
   form_placeholder: https://doi.org/10.3897/zookeys.209.3135
   display_property: dc:identifier:doi
-  display_snippet: link.html
+  display_snippet: doi.html
 
 - field_name: date_created
   label: Date Created

--- a/ckanext/digitizationknowledge/templates/scheming/display_snippets/doi.html
+++ b/ckanext/digitizationknowledge/templates/scheming/display_snippets/doi.html
@@ -1,0 +1,11 @@
+{% set doi = data[field.field_name] %}
+{% if doi and doi|string|trim %}
+{% set doi_text = doi|string|trim %}
+{% if doi_text.startswith('http://') or doi_text.startswith('https://') %}
+<a href="{{ doi_text }}" target="_blank" rel="{{ field.display_property or '' }}">{{ doi_text }}</a>
+{% else %}
+<a href="https://doi.org/{{ doi_text }}" target="_blank" rel="{{ field.display_property or '' }}">https://doi.org/{{ doi_text }}</a>
+{% endif %}
+{% else %}
+<span></span>
+{% endif %}


### PR DESCRIPTION
Blank <a> tags were being created when the DOI was empty causing issues with ADA