### PR TITLE
Update field ordering in resource_read.html template

### DIFF
--- a/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
+++ b/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
@@ -22,8 +22,8 @@
 {#- Example of type-specific ordering -#}
 {#- Uncomment and adapt this block for your dataset types
 {% if dataset_type == 'your_dataset_type_name' %}
-    {% set custom_order = ['date_created', 'date_published', 'date_modified', 'version', 'license', 'format'] %}
-    {% set custom_order_end = ['id'] %}
+    {% set custom_order = ['id','date_created', 'date_published', 'date_modified', 'version', 'license'] %}
+    {% set custom_order_end = ['format'] %}
 {% endif %}
 -#}
 


### PR DESCRIPTION
I made so the ID is always populated on the ckan resources table so that the ADA compliant reader doesn't detect an empty table, as id is always populated. This relate to issue #43.