### PR TITLE
Add `resource_actions` block for flexible action rendering

### DIFF
--- a/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
+++ b/ckanext/digitizationknowledge/templates/scheming/package/resource_read.html
@@ -7,6 +7,20 @@
 ] -%}
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
 
+{% block resource_actions %}
+  {% set rendered_resource_actions_inner %}
+    {% block resource_actions_inner %}
+      {{ super() }}
+    {% endblock %}
+  {% endset %}
+
+  {% if rendered_resource_actions_inner|string|trim %}
+    <ul class="d-flex flex-wrap gap-1 justify-content-end">
+      {{ rendered_resource_actions_inner|safe }}
+    </ul>
+  {% endif %}
+{% endblock %}
+
 {#-
 Define custom field orders. You can specify a default order and then
 override it for specific dataset types.


### PR DESCRIPTION
```
### Description

This pull request adds a `resource_actions` block in `resource_read.html`, enabling enhanced rendering and layout flexibility for resource actions.

### Related Issues

N/A

### Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
```