### PR TITLE
Update `robots.txt` to block SiteimproveBot from snippet API

### DIFF
--- a/ckanext/digitizationknowledge/templates/home/robots.txt
+++ b/ckanext/digitizationknowledge/templates/home/robots.txt
@@ -3,6 +3,8 @@
 {% block additional_user_agents -%}
 # Siteimprove crawler rules
 User-agent: SiteimproveBot
+Disallow: /api/1/util/snippet/
+Disallow: /api/util/snippet/
 Disallow: /digitization-resource?
 Disallow: /digitization-resource/?
 Allow: /digitization-resource/?page=
@@ -10,6 +12,8 @@ Allow: /digitization-resource?page=
 Allow: /digitization-resource/?task_clusters=digital+imaging&digitization_academy_course=Digital+Imaging+for+Biodiversity+Collections&discipline=general
 
 User-agent: SiteimproveBot-Crawler
+Disallow: /api/1/util/snippet/
+Disallow: /api/util/snippet/
 Disallow: /digitization-resource?
 Disallow: /digitization-resource/?
 Allow: /digitization-resource/?page=


### PR DESCRIPTION
Updated the `robots.txt` file to disallow SiteimproveBot access to specific snippet-related API endpoints. This change aims to improve access control and reduce unnecessary bot traffic.