### PR TITLE
Add empty `alt` attributes to decorative images for accessibility compliance

### DIFF
--- a/ckanext/digitizationknowledge/templates/home/index.html
+++ b/ckanext/digitizationknowledge/templates/home/index.html
@@ -78,7 +78,7 @@
         </h3>
         <div class="home-about-blocks">
           <div class="home-about-block">
-            <img src="/base/images/dk-owl-aggregate-red.svg" class="home-about-block__graphic">
+            <img src="/base/images/dk-owl-aggregate-red.svg" class="home-about-block__graphic" alt="">
             <div class="home-about-block__content">
 
               <h3 class="home-about-block__headline">
@@ -90,7 +90,7 @@
             </div>
           </div>
           <div class="home-about-block">
-            <img src="/base/images/dk-owl-enrich-yellow.svg" class="home-about-block__graphic">
+            <img src="/base/images/dk-owl-enrich-yellow.svg" class="home-about-block__graphic" alt="">
             <div class="home-about-block__content">
 
               <h3 class="home-about-block__headline">
@@ -102,7 +102,7 @@
             </div>
           </div>
           <div class="home-about-block">
-            <img src="/base/images/dk-owl-engage-green.svg" class="home-about-block__graphic">
+            <img src="/base/images/dk-owl-engage-green.svg" class="home-about-block__graphic" alt="">
             <div class="home-about-block__content">
 
               <h3 class="home-about-block__headline">


### PR DESCRIPTION
### Description

This pull request ensures decorative images follow accessibility guidelines by adding empty `alt` attributes. This helps screen readers skip non-informative visuals, improving user experience for visually impaired users.
