### PR TITLE
Update search form heading for better semantic structure

### DIFF
--- a/ckanext/digitizationknowledge/templates/snippets/search_form.html
+++ b/ckanext/digitizationknowledge/templates/snippets/search_form.html
@@ -1,13 +1,13 @@
 {% ckan_extends %}
 
 {% block search_title %}
-<h1>
+<h2 class="h1">
 {% if not error %}
   {% snippet 'snippets/search_result_text.html', query=query, count=count, type=type %}
 {% else %}
   Error
 {% endif %}
-</h1>
+</h2>
 {% endblock %}
 
 


### PR DESCRIPTION
No specific template was provided, so there is no additional description or structure to include here. The commit reflects an accessibility-focused improvement by changing the search form heading to `<h2>`. If you have a specific template you'd like me to use, please provide it!